### PR TITLE
Fix: db does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /mvnw
 /mvnw.cmd
 /logs
+*.iml

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -16,7 +16,7 @@ spring.servlet.multipart.max-file-size=-1
 spring.servlet.multipart.max-request-size=-1
 
 # DataSource
-spring.datasource.url=jdbc:sqlite:db/go-fastdfs.db
+spring.datasource.url=jdbc:sqlite::resource:db/go-fastdfs.db
 spring.datasource.driver-class-name=org.sqlite.JDBC
 
 # Thymeleaf Configuration


### PR DESCRIPTION
Refer: https://blog.csdn.net/sxy12138/article/details/52304884

And bug report: can not connect to `big cluster` deployed by https://sjqzhang.gitee.io/go-fastdfs/install.html#big-cluster that uploads file using url `http://localhost:8080/godfs/upload`

Repo here: https://github.com/Ten-AI/go-fastdfsr