### PR TITLE
fix Long.valueOf()超出范围

### DIFF
--- a/src/main/java/com/perfree/service/IndexService.java
+++ b/src/main/java/com/perfree/service/IndexService.java
@@ -40,11 +40,11 @@ public class IndexService {
         // 已使用空间
         result.put("diskUsedSize",FileSizeUtil.GetLength(Long.valueOf(JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("used"))));
         // 节点
-        result.put("inodesTotal",Long.valueOf(JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesTotal")));
+        result.put("inodesTotal", JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesTotal"));
         // 节点
-        result.put("inodesUsed",Long.valueOf(JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesUsed")));
+        result.put("inodesUsed", JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesUsed"));
         // 节点
-        result.put("inodesFree",Long.valueOf(JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesFree")));
+        result.put("inodesFree", JSONUtil.parseObj(parseObj.get("Sys.DiskInfo")).getStr("inodesFree"));
         long dayFileSize = 0;
         long dayFileCount = 0;
         for (int i = 0;i < parseArray.size();i++) {


### PR DESCRIPTION
"Sys.DiskInfo": {
"free": 246198038528,
"fstype": "apfs",
"inodesFree": 9223372036851609000,
"inodesTotal": 9223372036854776000,
"inodesUsed": 3167551,
"inodesUsedPercent": 3.434265675658632e-11,
"path": "/Users/stefan/Desktop/base-service/file-server/server",
"total": 500068036608,
"used": 249929961472,
"usedPercent": 50.376104850361195
}